### PR TITLE
fix: read and write quoted commodity symbols (e.g. B3 tickers like "WEGE3")

### DIFF
--- a/src/parser/ast.ts
+++ b/src/parser/ast.ts
@@ -473,10 +473,12 @@ export function processAutoPostingEntries(entries: AutoPostingEntry[], accountMa
 
 // Parse Price Directive
 export function parsePriceDirective(line: string, commodities?: Map<string, Commodity>): PriceDirective | null {
-  const match = line.match(/^P\s+(\d{4}[-/.]\d{2}[-/.]\d{2})\s+(\S+)\s+(.+?)(\s*;.*)?$/);
+  // Commodity may be quoted ("WEGE3") when it contains digits/spaces, per hledger.
+  const match = line.match(/^P\s+(\d{4}[-/.]\d{2}[-/.]\d{2})\s+("[^"]+"|\S+)\s+(.+?)(\s*;.*)?$/);
   if (!match) return null;
 
-  const [, date, commodity, amountStr, commentPart] = match;
+  const [, date, commodityRaw, amountStr, commentPart] = match;
+  const commodity = stripQuotes(commodityRaw);
   const amount = parseAmount(amountStr.trim(), undefined, commodities);
   if (!amount) return null;
 
@@ -872,6 +874,30 @@ export function parseAmount(amountStr: string, decimalMark?: DecimalMark, commod
   };
 
   const patterns = [
+    {
+      // Quoted symbol on right (e.g. 9 "WEGE3", -3 "VALE3").
+      // hledger requires quotes for symbols containing digits/spaces (B3 tickers).
+      // The stored commodity is the unquoted content.
+      pattern: /^([+-]?\s*\d[\d.,\s]*?)\s*"([^"]+)"$/,
+      handler: (m: RegExpMatchArray) => {
+        const rawAmount = m[1];
+        const { decimalMark: mark } = detectNumberFormat(rawAmount, effectiveDecimalMark(m[2]));
+        return { quantity: parseNumberWithFormat(rawAmount, toMarkArg(mark)), commodity: m[2], rawAmount };
+      },
+      cleaner: (m: RegExpMatchArray, s: string) => s.replace(m[1], m[1].replace(/[+-]/, ''))
+    },
+    {
+      // Quoted symbol on left (e.g. "WEGE3" 9, "My Stock" -2).
+      pattern: /^([+-]?)\s*"([^"]+)"\s*([+-]?\s*\d[\d.,\s]*)$/,
+      handler: (m: RegExpMatchArray) => {
+        const sign = m[1];
+        const rawAmount = m[3];
+        const { decimalMark: mark } = detectNumberFormat(rawAmount, effectiveDecimalMark(m[2]));
+        const quantity = parseNumberWithFormat(rawAmount, toMarkArg(mark));
+        return { quantity: sign === '-' ? -Math.abs(quantity) : quantity, commodity: m[2], rawAmount };
+      },
+      cleaner: (m: RegExpMatchArray, s: string) => s.replace(m[3], m[3].replace(/[+-]/, ''))
+    },
     {
       // Symbol on left, with sign prefix (e.g. -$100, +$100, - $100, + $100)
       pattern: /^([+-])\s*([^\d\s+-]+)\s*([+-]?\d[\d.,\s]*)$/,

--- a/src/utils/amountFormatter.ts
+++ b/src/utils/amountFormatter.ts
@@ -4,6 +4,7 @@
 
 import { ParsedDocument, Amount, Format } from '../types';
 import { FormattingOptions, DEFAULT_FORMATTING_OPTIONS } from '../server/settings';
+import { quoteCommodityIfNeeded } from './index';
 
 export interface AmountLayout {
   marker: string;
@@ -154,16 +155,20 @@ export function getAmountLayout(amount: Amount, parsed: ParsedDocument, options:
     negPosSign = '-';
   }
 
+  // Symbols are stored unquoted; re-add quotes when hledger requires them
+  // (e.g. B3 tickers), otherwise the rendered amount cannot be parsed back.
+  const symbol = quoteCommodityIfNeeded(format?.symbol || amount.commodity || '');
+
   return {
     marker: marker,
-    commodityBefore: symbolOnLeft ? format?.symbol || amount.commodity || '' : '',
+    commodityBefore: symbolOnLeft ? symbol : '',
     negPosSign: negPosSign,
     negativeSignBeforeCommodity: negativeSignBefore,
     amountIntegerString,
     amountDecimalString,
     decimalMark: (targetPrecision !== undefined && targetPrecision > 0) || amountDecimalString.length > 0 ? (format.decimalMark || '.') : '',
     spaceBetweenCommodityAndAmount,
-    commodityAfter: !symbolOnLeft ? format?.symbol || amount.commodity || '' : ''
+    commodityAfter: !symbolOnLeft ? symbol : ''
   };
 }
 

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -153,3 +153,17 @@ export function stripQuotes(s: string): string {
   if (t.length >= 2 && t.startsWith('"') && t.endsWith('"')) return t.substring(1, t.length - 1);
   return t;
 };
+
+/**
+ * Wrap a commodity symbol in quotes when hledger requires it.
+ *
+ * hledger only accepts a bare symbol when it has no digits, whitespace or
+ * sign characters; symbols like B3 tickers (WEGE3, TAEE11) must be written
+ * as "WEGE3" or they are read as part of the number. Symbols are stored
+ * unquoted internally (see stripQuotes), so quoting happens on output.
+ */
+export function quoteCommodityIfNeeded(symbol: string): string {
+  if (!symbol) return symbol;
+  if (symbol.length >= 2 && symbol.startsWith('"') && symbol.endsWith('"')) return symbol;
+  return /[\d\s+\-"]/.test(symbol) ? `"${symbol}"` : symbol;
+}

--- a/tests/parser/quotedCommodity.test.ts
+++ b/tests/parser/quotedCommodity.test.ts
@@ -1,0 +1,151 @@
+import { TextDocument } from 'vscode-languageserver-textdocument';
+import { HledgerParser } from '../../src/parser/index';
+import { parseAmount, parsePosting, parsePriceDirective } from '../../src/parser/ast';
+import { Validator } from '../../src/features/validator';
+
+function parseDoc(content: string) {
+  const doc = TextDocument.create('file:///test.journal', 'hledger', 1, content);
+  const parser = new HledgerParser();
+  return { doc, parsed: parser.parse(doc) };
+}
+
+/**
+ * hledger requires commodity symbols that end in a digit (e.g. B3 tickers like
+ * "WEGE3") to be wrapped in double quotes. The stored commodity symbol is the
+ * unquoted content, matching how the `commodity` directive registers it.
+ */
+describe('quoted commodity symbols (B3 tickers)', () => {
+  describe('parseAmount', () => {
+    it('parses a number followed by a quoted commodity: 9 "WEGE3"', () => {
+      const result = parseAmount('9 "WEGE3"');
+      expect(result).not.toBeNull();
+      expect(result?.quantity).toBe(9);
+      expect(result?.commodity).toBe('WEGE3');
+    });
+
+    it('strips the quotes from the commodity symbol', () => {
+      const result = parseAmount('18 "RADL3"');
+      expect(result?.commodity).toBe('RADL3');
+      expect(result?.commodity).not.toContain('"');
+    });
+
+    it('parses a negative quantity with a quoted commodity: -3 "VALE3"', () => {
+      const result = parseAmount('-3 "VALE3"');
+      expect(result).not.toBeNull();
+      expect(result?.quantity).toBe(-3);
+      expect(result?.commodity).toBe('VALE3');
+    });
+
+    it('parses a quoted commodity on the left: "WEGE3" 9', () => {
+      const result = parseAmount('"WEGE3" 9');
+      expect(result).not.toBeNull();
+      expect(result?.quantity).toBe(9);
+      expect(result?.commodity).toBe('WEGE3');
+    });
+
+    it('parses a quoted commodity containing spaces: 2 "My Stock"', () => {
+      const result = parseAmount('2 "My Stock"');
+      expect(result).not.toBeNull();
+      expect(result?.quantity).toBe(2);
+      expect(result?.commodity).toBe('My Stock');
+    });
+
+    it('sets the format symbol to the unquoted commodity', () => {
+      const result = parseAmount('9 "WEGE3"');
+      expect(result?.format?.symbol).toBe('WEGE3');
+    });
+  });
+
+  describe('parsePosting with quoted commodity amount and cost', () => {
+    it('parses "9 \\"WEGE3\\" @ R$ 43,19" into amount + unit cost', () => {
+      const posting = parsePosting('    assets:inter:rv:WEGE3    9 "WEGE3"   @  R$ 43,19');
+      expect(posting).not.toBeNull();
+      expect(posting?.account).toBe('assets:inter:rv:WEGE3');
+      expect(posting?.amount?.quantity).toBe(9);
+      expect(posting?.amount?.commodity).toBe('WEGE3');
+      expect(posting?.cost?.type).toBe('unit');
+      expect(posting?.cost?.amount?.commodity).toBe('R$');
+      expect(posting?.cost?.amount?.quantity).toBeCloseTo(43.19);
+    });
+  });
+
+  describe('parsePriceDirective', () => {
+    it('strips quotes from a quoted commodity: P ... "WEGE3" R$ 43,49', () => {
+      const result = parsePriceDirective('P 2026-07-16 "WEGE3" R$ 43,49');
+      expect(result).not.toBeNull();
+      expect(result?.commodity).toBe('WEGE3');
+      expect(result?.amount.commodity).toBe('R$');
+      expect(result?.amount.quantity).toBeCloseTo(43.49);
+    });
+  });
+
+  describe('commodity directive registration', () => {
+    it('registers the ticker unquoted from `commodity 1. "WEGE3"`', () => {
+      const { parsed } = parseDoc('commodity 1. "WEGE3"');
+      const commodity = parsed.commodities.get('WEGE3');
+      expect(commodity).toBeDefined();
+      expect(commodity?.declared).toBe(true);
+      // No quoted variant should leak into the map.
+      expect(parsed.commodities.has('"WEGE3"')).toBe(false);
+    });
+
+    it('price directive commodity matches the declared ticker (single map entry)', () => {
+      const { parsed } = parseDoc([
+        'commodity 1. "WEGE3"',
+        'P 2026-07-16 "WEGE3" R$ 43,49',
+      ].join('\n'));
+      expect(parsed.commodities.has('WEGE3')).toBe(true);
+      expect(parsed.commodities.get('WEGE3')?.declared).toBe(true);
+      expect(parsed.commodities.has('"WEGE3"')).toBe(false);
+    });
+  });
+});
+
+/**
+ * The two user-reported regressions for B3 tickers:
+ *  1. declared tickers reported as "Undeclared"
+ *  2. "N postings without amounts" because the amount fails to parse
+ */
+describe('B3 ticker regressions (integration)', () => {
+  const content = [
+    'commodity R$ 1.234,56',
+    'commodity 1. "WEGE3"',
+    'commodity 1. "VALE3"',
+    '',
+    'account assets:inter:rv:WEGE3',
+    'account assets:inter:rv:VALE3',
+    'account assets:inter:investimentos-lump',
+    '',
+    'P 2026-07-16 "WEGE3" R$ 43,49',
+    '',
+    '2026-07-16 * Conversão lump -> carteira RV',
+    '    assets:inter:rv:WEGE3                    9 "WEGE3"   @  R$ 43,19',
+    '    assets:inter:rv:VALE3                    3 "VALE3"   @  R$ 57,77',
+    '    assets:inter:investimentos-lump',
+  ].join('\n');
+
+  it('does not report declared tickers as undeclared commodities', () => {
+    const { doc, parsed } = parseDoc(content);
+    const result = new Validator().validate(doc, parsed);
+    const undeclared = result.diagnostics.filter(d =>
+      d.code === 'undeclared-commodity' && /WEGE3|VALE3/.test(d.message)
+    );
+    expect(undeclared).toHaveLength(0);
+  });
+
+  it('does not report "postings without amounts" for quoted-commodity postings', () => {
+    const { doc, parsed } = parseDoc(content);
+    const result = new Validator().validate(doc, parsed);
+    const missing = result.diagnostics.filter(d => /postings without amounts/.test(d.message));
+    expect(missing).toHaveLength(0);
+  });
+
+  it('parses the quoted amounts on every stock posting', () => {
+    const { parsed } = parseDoc(content);
+    const tx = parsed.transactions[0];
+    expect(tx.postings[0].amount?.commodity).toBe('WEGE3');
+    expect(tx.postings[0].amount?.quantity).toBe(9);
+    expect(tx.postings[1].amount?.commodity).toBe('VALE3');
+    expect(tx.postings[1].amount?.quantity).toBe(3);
+  });
+});

--- a/tests/parser/quotedCommodity.test.ts
+++ b/tests/parser/quotedCommodity.test.ts
@@ -2,6 +2,9 @@ import { TextDocument } from 'vscode-languageserver-textdocument';
 import { HledgerParser } from '../../src/parser/index';
 import { parseAmount, parsePosting, parsePriceDirective } from '../../src/parser/ast';
 import { Validator } from '../../src/features/validator';
+import { formatAmount } from '../../src/utils/amountFormatter';
+import { quoteCommodityIfNeeded } from '../../src/utils/index';
+import { isSafeToFormat } from '../../src/features/formattingValidation';
 
 function parseDoc(content: string) {
   const doc = TextDocument.create('file:///test.journal', 'hledger', 1, content);
@@ -99,6 +102,40 @@ describe('quoted commodity symbols (B3 tickers)', () => {
       expect(parsed.commodities.has('"WEGE3"')).toBe(false);
     });
   });
+
+  describe('formatAmount re-adds the quotes', () => {
+    const { parsed } = parseDoc([
+      'commodity 1. "WEGE3"',
+      '',
+      '2026-07-16 * Compra',
+      '    assets:rv:WEGE3    9 "WEGE3"',
+      '    assets:caixa',
+    ].join('\n'));
+
+    it('quotes a ticker symbol on output', () => {
+      expect(formatAmount(9, 'WEGE3', parsed)).toContain('"WEGE3"');
+    });
+
+    it('leaves plain symbols unquoted', () => {
+      expect(formatAmount(10, 'USD', parsed)).not.toContain('"');
+    });
+
+    it('round-trips: format -> parse gives the same quantity and commodity', () => {
+      const formatted = formatAmount(9, 'WEGE3', parsed);
+      const reparsed = parseAmount(formatted);
+      expect(reparsed).not.toBeNull();
+      expect(reparsed?.quantity).toBe(9);
+      expect(reparsed?.commodity).toBe('WEGE3');
+    });
+
+    it('does not double-quote an already quoted symbol', () => {
+      expect(quoteCommodityIfNeeded('"WEGE3"')).toBe('"WEGE3"');
+    });
+
+    it('quotes symbols containing spaces', () => {
+      expect(quoteCommodityIfNeeded('My Stock')).toBe('"My Stock"');
+    });
+  });
 });
 
 /**
@@ -138,6 +175,20 @@ describe('B3 ticker regressions (integration)', () => {
     const result = new Validator().validate(doc, parsed);
     const missing = result.diagnostics.filter(d => /postings without amounts/.test(d.message));
     expect(missing).toHaveLength(0);
+  });
+
+  it('does not report the round-trip failure "9 WEGE3 cannot be parsed back"', () => {
+    const { doc, parsed } = parseDoc(content);
+    const result = new Validator().validate(doc, parsed);
+    const roundTrip = result.diagnostics.filter(d => d.code === 'format-roundtrip-failed');
+    expect(roundTrip).toHaveLength(0);
+  });
+
+  it('considers quoted-commodity postings safe to format', () => {
+    const { parsed } = parseDoc(content);
+    const postings = parsed.transactions[0].postings;
+    expect(isSafeToFormat(postings[0], parsed)).toBe(true);
+    expect(isSafeToFormat(postings[1], parsed)).toBe(true);
   });
 
   it('parses the quoted amounts on every stock posting', () => {


### PR DESCRIPTION
## Problem

hledger requires commodity symbols that end in a digit to be wrapped in double quotes (e.g. B3 stock tickers like `"WEGE3"`, `"VALE3"`, `"PETR4"`). The LSP did not handle these quoted symbols, which broke any ledger tracking Brazilian (B3) stocks in three ways:

1. **Declared tickers reported as "Undeclared".** A `commodity 1. "WEGE3"` directive registers the symbol *unquoted* (`WEGE3`), but a `P` price directive stored it *with* quotes (`"WEGE3"`). The two never matched, so the declared commodity was flagged as undeclared.
2. **"N postings without amounts" errors.** A posting such as `9 "WEGE3" @ R$ 43,19` failed to parse its amount, because the commodity-matching regexes excluded digits and the trailing `3` in the ticker broke the match. With no amount parsed, the transaction looked like it had multiple amountless postings.
3. **Formatting refused, with `format-roundtrip-failed`.** Symbols are stored unquoted, but the formatter emitted them bare, so `9 "WEGE3"` rendered as `9 WEGE3` — which does not parse back. The round-trip guard in `formattingValidation` correctly caught this and reported:

   ```
   Cannot safely format amount: formatted value "9 WEGE3" cannot be parsed back
   ```

   The guard was right; the write path was wrong. Note this affects the current release too: without the round-trip guard those postings would be silently rewritten to an unparseable form, so any symbol needing quotes is unsafe to format today.

## Fix

Read path:

- `parseAmount` now recognizes a quoted commodity on either side of the number (`9 "WEGE3"` and `"WEGE3" 9`) and stores the **unquoted** symbol, consistent with how the `commodity` directive registers it.
- `parsePriceDirective` accepts a quoted commodity and strips the quotes, so the price commodity matches the declared one.

Write path:

- New `quoteCommodityIfNeeded` helper in `src/utils/index.ts`, the counterpart to the existing `stripQuotes`. It quotes a symbol that contains a digit, whitespace or a sign character, and never double-quotes an already quoted one.
- Applied in `getAmountLayout` (`src/utils/amountFormatter.ts`) rather than at each call site, so the formatter, inlay hints, hover, code actions and balance assertions are all covered by one change, and the alignment widths already account for the quotes since they derive from the layout.

Quoting stays purely a rendering concern: symbols remain unquoted everywhere in the pipeline, keeping a single `parsed.commodities` entry per commodity.

## Tests

Added `tests/parser/quotedCommodity.test.ts` (20 cases) covering all three reported bugs: `parseAmount`, `parsePosting` with a unit cost, `parsePriceDirective`, commodity-directive registration, `formatAmount` quoting and format→parse round-trip, plus Validator integration tests asserting no `undeclared-commodity`, no `postings without amounts` and no `format-roundtrip-failed` diagnostics.

- Full suite green (1259 tests, no existing tests modified).
- No new lint issues introduced.

Verified against a real journal with 12 B3 tickers: zero `format-*` diagnostics, and the quotes survive a formatting pass.
